### PR TITLE
codespaces - auto forward required ports

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,5 +16,6 @@
         }
     },
     "postCreateCommand": "cd tina-hugo-starter && pnpm install && pnpm run dev",
+    "forwardPorts": [1313, 4001],
     "remoteUser": "node"
 }


### PR DESCRIPTION
This pull request includes a small change to the `.devcontainer/devcontainer.json` file. The change adds port forwarding for ports 1313 and 4001 to the development container configuration.

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R19): Added `forwardPorts` configuration to forward ports 1313 and 4001.